### PR TITLE
Add scripts-to-rule-them-all

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install requirements
+pip install --quiet --requirement requirements.txt

--- a/script/test
+++ b/script/test
@@ -1,0 +1,21 @@
+# Install cld2-cffi package with an additional CFLAG
+CFLAGS="-Wno-narrowing" pip3 install --quiet cld2-cffi
+
+# Install requirements
+pip3 install --quiet --requirement requirements.txt
+
+# Install and run pylint
+pip3 install --quiet --upgrade pylint 
+python3 -m pylint -f parseable textpipe | tee pylint.out
+
+# Download languages needed for testing
+python3 -m spacy download nl > /dev/null
+python3 -m spacy download en > /dev/null
+
+# Run test with pytest, including doctests
+pip3 install --quiet --upgrade pytest
+python3 -m pytest --doctest-modules --junit-xml=pytest.xml
+
+# Run unit tests again, but with nose for coverage report
+pip3 install --quiet --upgrade nosexcover
+python3 -m nose --with-doctest --with-xcoverage --with-xunit --cover-package=textpipe --cover-erase 2> /dev/null

--- a/script/test
+++ b/script/test
@@ -2,22 +2,20 @@
 
 set -e
 
-# Install cld2-cffi package with an additional CFLAG
-CFLAGS="-Wno-narrowing" pip3 install --quiet cld2-cffi
+script/bootstrap
 
-# Install requirements and test requirements
-pip3 install --quiet --requirement requirements.txt
-pip3 install --quiet --requirement test-requirements.txt
+# Install test requirements
+pip install --quiet --requirement test-requirements.txt
 
 # Run linting
-python3 -m pylint -f parseable textpipe | tee pylint.out
+python -m pylint -f parseable textpipe | tee pylint.out
 
 # Download languages needed for testing
-python3 -m spacy download nl > /dev/null
-python3 -m spacy download en > /dev/null
+python -m spacy download nl > /dev/null
+python -m spacy download en > /dev/null
 
 # Run test with pytest, including doctests
-python3 -m pytest --doctest-modules --junit-xml=pytest.xml
+python -m pytest --doctest-modules --junit-xml=pytest.xml
 
 # Run unit tests again, but with nose for coverage report
-python3 -m nose --with-doctest --with-xcoverage --with-xunit --cover-package=textpipe --cover-erase 2> /dev/null
+python -m nose --with-doctest --with-xcoverage --with-xunit --cover-package=textpipe --cover-erase 2> /dev/null

--- a/script/test
+++ b/script/test
@@ -1,11 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
 # Install cld2-cffi package with an additional CFLAG
 CFLAGS="-Wno-narrowing" pip3 install --quiet cld2-cffi
 
-# Install requirements
+# Install requirements and test requirements
 pip3 install --quiet --requirement requirements.txt
+pip3 install --quiet --requirement test-requirements.txt
 
-# Install and run pylint
-pip3 install --quiet --upgrade pylint 
+# Run linting
 python3 -m pylint -f parseable textpipe | tee pylint.out
 
 # Download languages needed for testing
@@ -13,9 +17,7 @@ python3 -m spacy download nl > /dev/null
 python3 -m spacy download en > /dev/null
 
 # Run test with pytest, including doctests
-pip3 install --quiet --upgrade pytest
 python3 -m pytest --doctest-modules --junit-xml=pytest.xml
 
 # Run unit tests again, but with nose for coverage report
-pip3 install --quiet --upgrade nosexcover
 python3 -m nose --with-doctest --with-xcoverage --with-xunit --cover-package=textpipe --cover-erase 2> /dev/null

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+nosexcover~=1.0.11
+pylint~=1.9.2
+pytest~=3.6.2


### PR DESCRIPTION
This adds `script/test` and `script/bootstrap`, with code as described in #1  (adding config for running this on CI is left for a separate PR).