### PR TITLE
Adds is_reliable_language property to language detection

### DIFF
--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -48,7 +48,7 @@ def test_load_custom_model():
     The custom spacy language modules should be correctly loaded into the doc.
     """
     model_mapping = {'nl': 'ents'}
-    lang = DOC_5.hint_language if DOC_5.language == 'un' else DOC_5.language
+    lang = DOC_5.language if DOC_5.is_reliable_language else DOC_5.hint_language
     assert lang == 'nl'
     assert sorted(DOC_5.find_ents()) == sorted([('Mark Zuckerberg', 'PER'), ('Facebook', 'MISC')])
     assert DOC_5.find_ents(model_mapping[lang]) == []

--- a/textpipe/doc.py
+++ b/textpipe/doc.py
@@ -98,7 +98,7 @@ class Doc:
                                                    hintLanguage=hint_language,
                                                    bestEffort=True)
 
-        if len(best_guesses) == 0 or len(best_guesses[0]) != 4:
+        if len(best_guesses) == 0 or len(best_guesses[0]) != 4 or best_guesses[0][1] == 'un':
             return False, 'un'
 
         return is_reliable, best_guesses[0][1]
@@ -112,7 +112,7 @@ class Doc:
         >>> type(doc._spacy_doc)
         <class 'spacy.tokens.doc.Doc'>
         """
-        lang = self.hint_language if self.language == 'un' else self.language
+        lang = self.language if self.is_reliable_language else self.hint_language
 
         return self._load_spacy_doc(lang)
 
@@ -188,7 +188,7 @@ class Doc:
         >>> doc.find_ents()
         [('Google', 'ORG')]
         """
-        lang = self.hint_language if self.language == 'un' else self.language
+        lang = self.language if self.is_reliable_language else self.hint_language
         return list({(ent.text, ent.label_) for ent in self._load_spacy_doc(lang, model_name).ents})
 
     @property

--- a/textpipe/operation.py
+++ b/textpipe/operation.py
@@ -114,5 +114,5 @@ class Entities(Operation):
         self.model_mapping = model_mapping
 
     def __call__(self, doc):
-        lang = doc.hint_language if doc.language == 'un' else doc.language
+        lang = doc.language if doc.is_reliable_language else doc.hint_language
         return doc.find_ents(self.model_mapping[lang]) if self.model_mapping else doc.ents


### PR DESCRIPTION
Follow up from the discussion in https://github.com/textpipe/textpipe/pull/53#discussion_r210245818, I made the language detection a bit more robust and expose the `is_reliable_language` property from  [cld2-cffi](https://github.com/GregBowyer/cld2-cffi/#documentation).