### PR TITLE
Add spacy word vectors to Doc

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@
 * Jeroen Jansze (De Persgroep)
 * Bart de Goede
 * Joris Baan (UvA)
+* Rana Klein (RTL)

--- a/textpipe/doc.py
+++ b/textpipe/doc.py
@@ -436,7 +436,7 @@ class Doc:
         >>> doc = Doc('Test sentence')
         >>> doc.word_vectors['Test']['is_oov']
         True
-        >>> doc.word_vectors['Test']['vector'].shape[-1]
+        >>> len(doc.word_vectors['Test']['vector'])
         384
         >>> doc.word_vectors['Test']['vector_norm'] == doc.word_vectors['sentence']['vector_norm']
         False
@@ -444,7 +444,7 @@ class Doc:
         return {token.text: {'has_vector': token.has_vector,
                              'vector_norm': token.vector_norm,
                              'is_oov': token.is_oov,
-                             'vector': token.vector}
+                             'vector': token.vector.tolist()}
                 for token in self._spacy_doc}
 
     @property
@@ -474,8 +474,8 @@ class Doc:
         >>> numpy.array_equiv(doc1.aggregate_word_vectors(aggregation='mean'), doc2.aggregate_word_vectors(aggregation='sum'))
         False
         >>> doc = Doc('sentence with an out of vector word lsseofn')
-        >>> doc.aggregate_word_vectors().shape
-        (384,)
+        >>> len(doc.aggregate_word_vectors())
+        384
         >>> numpy.array_equiv(doc.aggregate_word_vectors(exclude_oov=False), doc.aggregate_word_vectors(exclude_oov=True))
         False
         """
@@ -484,8 +484,8 @@ class Doc:
                    for token in tokens]
 
         if aggregation == 'mean':
-            return numpy.mean(vectors, axis=0)
+            return numpy.mean(vectors, axis=0).tolist()
         elif aggregation == 'sum':
-            return numpy.sum(vectors, axis=0)
+            return numpy.sum(vectors, axis=0).tolist()
         else:
             raise NotImplementedError(f'Aggregation method {aggregation} is not implemented.')

--- a/textpipe/doc.py
+++ b/textpipe/doc.py
@@ -414,11 +414,11 @@ class Doc:
         else:
             raise NotImplementedError(f'Metric/hash method combination {metric}'
                                       f'/{hash_method} is not implemented as similarity metric')
-   
+
     @property
     def word_vectors(self):
         """
-        Returns word embeddings for the words in the document
+        Returns word embeddings for the words in the document.
         """
         return self.generate_word_vectors()
    
@@ -492,7 +492,7 @@ class Doc:
         tokens = [token for token in self._load_spacy_doc(lang, model_name) if not exclude_oov or not token.is_oov]
         vectors = [token.vector / token.vector_norm if normalize else token.vector
                    for token in tokens]
-                   
+
         if aggregation == 'mean':
             return numpy.mean(vectors, axis=0).tolist()
         elif aggregation == 'sum':

--- a/textpipe/doc.py
+++ b/textpipe/doc.py
@@ -421,7 +421,7 @@ class Doc:
         Returns word embeddings for the words in the document.
         """
         return self.generate_word_vectors()
-   
+
     @functools.lru_cache()
     def generate_word_vectors(self, model_name=None):
         """

--- a/textpipe/operation.py
+++ b/textpipe/operation.py
@@ -268,12 +268,14 @@ class WordVectors(Operation):
     >>> WordVectors()(doc)['Sentence']['has_vector']
     True
     """
-    def __init__(self, **kwargs):
+    def __init__(self, model_mapping=None, **kwargs):
+        self.model_mapping = model_mapping
         self.kwargs = kwargs
 
     def __call__(self, doc):
         lang = doc.language if doc.is_reliable_language else doc.hint_language
-        return doc.generate_word_vectors(**self.kwargs)
+        return (doc.generate_word_vectors(self.model_mapping[lang])
+                if self.model_mapping else doc.word_vectors)
 
 
 class DocumentVector(Operation):
@@ -285,9 +287,11 @@ class DocumentVector(Operation):
     >>> len(DocumentVector()(doc))
     384
     """
-    def __init__(self, **kwargs):
+    def __init__(self, model_mapping=None, **kwargs):
+        self.model_mapping = model_mapping
         self.kwargs = kwargs
 
     def __call__(self, doc):
         lang = doc.language if doc.is_reliable_language else doc.hint_language
-        return doc.aggregate_word_vectors(**self.kwargs)
+        return (doc.aggregate_word_vectors(self.model_mapping[lang], **self.kwargs)
+                if self.model_mapping else doc.aggregate_word_vectors(**self.kwargs))

--- a/textpipe/operation.py
+++ b/textpipe/operation.py
@@ -281,8 +281,8 @@ class DocumentVector(Operation):
 
     >>> from textpipe.doc import Doc
     >>> doc = Doc('Sentence for vectorization')
-    >>> DocumentVector()(doc).shape
-    (384,)
+    >>> len(DocumentVector()(doc))
+    384
     """
     def __init__(self, **kwargs):
         self.kwargs = kwargs

--- a/textpipe/operation.py
+++ b/textpipe/operation.py
@@ -272,7 +272,8 @@ class WordVectors(Operation):
         self.kwargs = kwargs
 
     def __call__(self, doc):
-        return doc.word_vectors
+        lang = doc.language if doc.is_reliable_language else doc.hint_language
+        return doc.generate_word_vectors(**self.kwargs)
 
 
 class DocumentVector(Operation):
@@ -288,4 +289,5 @@ class DocumentVector(Operation):
         self.kwargs = kwargs
 
     def __call__(self, doc):
+        lang = doc.language if doc.is_reliable_language else doc.hint_language
         return doc.aggregate_word_vectors(**self.kwargs)

--- a/textpipe/operation.py
+++ b/textpipe/operation.py
@@ -239,6 +239,7 @@ class MinHash(Operation):
     Returns a list with integers, which is the minhash of the document.
     A minhash is a cheap way to compute a hash for finding similarity of documents.
     Source: https://ekzhu.github.io/datasketch/minhash.html
+
     >>> from textpipe.doc import Doc
     >>> doc = Doc('Sentence for computing the minhash')
     >>> doc.minhash[:5]
@@ -250,3 +251,41 @@ class MinHash(Operation):
 
     def __call__(self, doc):
         return doc.find_minhash(num_perm=self.num_perm)
+
+
+class WordVectors(Operation):
+    """
+    Extract the vectors of the words in a document.
+
+    Returns a dict that maps each word to a dict with the following keys:
+        'has_vector': True if the word has a vector
+        'vector_norm': The vector norm of the word
+        'is_oov': True if the word is out of vocabulary
+        'vector': The vector corresponding to the word
+
+    >>> from textpipe.doc import Doc
+    >>> doc = Doc('Sentence for vectorization')
+    >>> WordVectors()(doc)['Sentence']['has_vector']
+    True
+    """
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __call__(self, doc):
+        return doc.word_vectors
+
+
+class DocumentVector(Operation):
+    """
+    Extract the vector of the document.
+
+    >>> from textpipe.doc import Doc
+    >>> doc = Doc('Sentence for vectorization')
+    >>> DocumentVector()(doc).shape
+    (384,)
+    """
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __call__(self, doc):
+        return doc.aggregate_word_vectors(**self.kwargs)


### PR DESCRIPTION
This exposes spacy word vectors as a property of `Doc`. This closes #12.

Note that the Spacy models Textpipe typically uses (e.g. `en_core_web_sm` and `nl_core_news_sm`) do not contain vectors. Hence the generated vectors are [context-sensitive tensors](https://github.com/explosion/spaCy/issues/2523#issuecomment-403453356).

We are thinking of adding other word embeddings in a separate pull request, maybe based on [fastText](https://github.com/facebookresearch/fastText/) or [BERT](https://github.com/google-research/bert). We left an `Operator` implementation to add this to a `Pipeline` for when we have more general word vectors.