### PR TITLE
Remove pinning of msgpack-numpy==0.4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ cld2_cffi~=0.1
 spacy~=2.0
 textacy~=0.6
 textpipe-pattern==3.6
-msgpack-numpy==0.4.4 # pinning to avoid release 0.4.4.1 , can be removed with later releases.


### PR DESCRIPTION
This fixes the build on master, that was actually failing: https://travis-ci.com/textpipe/textpipe/builds/93408648

This pinning was added in #76 to avoid release msgpack-numpy==0.4.4.1, now 0.4.4.2 is released.