### PR TITLE
Do not error when SpaCy is installed as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ class PostInstallCommand(setuptools.command.install.install,
         try:
             import spacy
             return spacy.cli.validate()
-        except:
+        except ModuleNotFoundError:
             return
 
 with open(Path(__file__).resolve().parent.joinpath('README.md'), 'r') as fh:

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,11 @@ class PostInstallCommand(setuptools.command.install.install,
                          setuptools.command.develop.develop):
     """Post-installation for develop and installation mode."""
     def run(self):
-        import spacy
-        return spacy.cli.validate()
+        try:
+            import spacy
+            return spacy.cli.validate()
+        except:
+            return
 
 with open(Path(__file__).resolve().parent.joinpath('README.md'), 'r') as fh:
     long_description = fh.read()


### PR DESCRIPTION
I noticed that when `spacy` is installed as a depency of `textpipe`, the existing model validation actually fails. See https://travis-ci.org/svrijenhoek/dart/builds/512567113#L628. 